### PR TITLE
Add field to loader: last loaded model

### DIFF
--- a/Assets/GLTF/Scripts/GLTFLoader.cs
+++ b/Assets/GLTF/Scripts/GLTFLoader.cs
@@ -28,7 +28,17 @@ namespace GLTF
             public bool UseVertexColors;
         }
 
-        public GLTFLoader(string gltfUrl, Shader standardShader)
+		private GameObject lastLoadedModel;
+
+	    public GameObject LastLoadedModel
+	    {
+		    get
+		    {
+			    return lastLoadedModel;
+		    }
+	    }
+
+	    public GLTFLoader(string gltfUrl, Shader standardShader)
         {
             _gltfUrl = gltfUrl;
             _standardShader = standardShader;
@@ -100,6 +110,7 @@ namespace GLTF
 	        }
 
 			_root = null;
+	        lastLoadedModel = sceneObj;
         }
 
         private void ParseGLTF(byte[] gltfData)

--- a/Assets/GLTF/Scripts/GLTFLoader.cs
+++ b/Assets/GLTF/Scripts/GLTFLoader.cs
@@ -14,6 +14,7 @@ namespace GLTF
         private Shader _standardShader;
 		private readonly string _gltfUrl;
         private GLTFRoot _root;
+        private GameObject _lastLoadedScene;
         private AsyncAction asyncAction;
 	    private readonly Transform _sceneParent;
         private readonly Dictionary<GLTFBuffer, byte[]> _bufferCache = new Dictionary<GLTFBuffer, byte[]>();
@@ -27,16 +28,6 @@ namespace GLTF
             public GLTFMaterial Material;
             public bool UseVertexColors;
         }
-
-		private GameObject lastLoadedModel;
-
-	    public GameObject LastLoadedModel
-	    {
-		    get
-		    {
-			    return lastLoadedModel;
-		    }
-	    }
 
 	    public GLTFLoader(string gltfUrl, Shader standardShader)
         {
@@ -52,6 +43,14 @@ namespace GLTF
             _standardShader = standardShader;
             asyncAction = new AsyncAction();
 		}
+
+	    public GameObject LastLoadedScene
+	    {
+		    get
+		    {
+			    return _lastLoadedScene;
+		    }
+	    }
 
         public IEnumerator Load()
         {
@@ -110,7 +109,7 @@ namespace GLTF
 	        }
 
 			_root = null;
-	        lastLoadedModel = sceneObj;
+	        _lastLoadedScene = sceneObj;
         }
 
         private void ParseGLTF(byte[] gltfData)


### PR DESCRIPTION
It's strange to me that the loaded scene is discarded entirely if another game object is not given as its parent. This PR allows consumers to get the reference to the model after loading is complete.